### PR TITLE
Allow overriding listenAddress

### DIFF
--- a/src/main/java/io/dropwizard/discovery/DiscoveryFactory.java
+++ b/src/main/java/io/dropwizard/discovery/DiscoveryFactory.java
@@ -59,8 +59,8 @@ public class DiscoveryFactory {
     @NotEmpty
     private String serviceName;
 
-    @NotEmpty
-    private String listenAddress = "127.0.0.1";
+    @NotNull
+    private String listenAddress = "";
 
     @NotEmpty
     private String namespace = "dropwizard";
@@ -134,6 +134,11 @@ public class DiscoveryFactory {
     @JsonProperty
     public String getListenAddress() {
         return listenAddress;
+    }
+
+    @JsonProperty
+    public void setListenAddress(final String listenAddress) {
+        this.listenAddress = listenAddress;
     }
 
     @JsonProperty

--- a/src/test/java/io/dropwizard/discovery/core/CuratorAdvertiserTest.java
+++ b/src/test/java/io/dropwizard/discovery/core/CuratorAdvertiserTest.java
@@ -25,9 +25,10 @@ public class CuratorAdvertiserTest {
 
     @Test
     public void testInitListenInfo() throws Exception {
+        factory.setListenAddress("127.0.0.1");
         advertiser.initListenInfo(8080);
         assertThat(advertiser.getListenPort()).isEqualTo(8080);
-        assertThat(advertiser.getListenAddress()).isNotEqualTo("");
+        assertThat(advertiser.getListenAddress()).isEqualTo("127.0.0.1");
     }
 
     @Test


### PR DESCRIPTION
If listenAddress is specified in the configuration file, use its value, otherwise auto-detect and use first IPv4 address.

This fixes https://github.com/GeneralElectric/snowizard-discovery/issues/4
