### PR TITLE
Added support for storing the admin port in the `InstanceMetadata`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dropwizard.version>0.9.2</dropwizard.version>
-        <curator.version>3.0.0</curator.version>
+        <curator.version>2.10.0</curator.version>
     </properties>
 
     <profiles>
@@ -168,7 +168,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5</version>
+                <version>3.5.1</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>
@@ -182,7 +182,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -309,7 +309,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.8.1</version>
+                <version>2.9</version>
                 <configuration>
                     <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
                     <dependencyLocationsEnabled>false</dependencyLocationsEnabled>

--- a/src/main/java/io/dropwizard/discovery/DiscoveryBundle.java
+++ b/src/main/java/io/dropwizard/discovery/DiscoveryBundle.java
@@ -37,5 +37,4 @@ public abstract class DiscoveryBundle<T extends Configuration> extends
     public Class<InstanceMetadata> getPayloadClass() {
         return serviceInstanceFactory.getPayloadClass();
     }
-
 }

--- a/src/main/java/io/dropwizard/discovery/core/CuratorAdvertiser.java
+++ b/src/main/java/io/dropwizard/discovery/core/CuratorAdvertiser.java
@@ -7,6 +7,7 @@ import java.net.SocketException;
 import java.util.Collection;
 import java.util.UUID;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.curator.framework.CuratorFramework;
@@ -17,6 +18,7 @@ import org.apache.curator.x.discovery.ServiceInstance;
 import org.apache.curator.x.discovery.ServiceInstanceBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 
 @ThreadSafe
@@ -34,6 +36,9 @@ public class CuratorAdvertiser<T> implements ConnectionStateListener {
 
     @GuardedBy("this")
     private int listenPort = 0;
+
+    @GuardedBy("this")
+    private Integer adminPort = null;
 
     @GuardedBy("this")
     private ServiceInstance<T> instance;
@@ -60,9 +65,13 @@ public class CuratorAdvertiser<T> implements ConnectionStateListener {
      * 
      * @param port
      *            port this instance is listening on
+     * @param adminPort
+     *            optional admin port this instance is listening on
      */
-    public synchronized void initListenInfo(final int port) {
-        listenPort = port;
+    public synchronized void initListenInfo(final int port,
+            @Nullable final Integer adminPort) {
+        this.listenPort = port;
+        this.adminPort = adminPort;
 
         if (!Strings.isNullOrEmpty(configuration.getListenAddress())) {
             LOGGER.info("Using '{}' as listenAddress from configuration file",
@@ -166,6 +175,15 @@ public class CuratorAdvertiser<T> implements ConnectionStateListener {
      */
     public int getListenPort() {
         return listenPort;
+    }
+
+    /**
+     * Return the admin port
+     *
+     * @return port number
+     */
+    public Optional<Integer> getAdminPort() {
+        return Optional.fromNullable(adminPort);
     }
 
     /**

--- a/src/main/java/io/dropwizard/discovery/core/DefaultServiceInstanceFactory.java
+++ b/src/main/java/io/dropwizard/discovery/core/DefaultServiceInstanceFactory.java
@@ -10,7 +10,7 @@ public class DefaultServiceInstanceFactory implements
             CuratorAdvertiser<InstanceMetadata> advertiser) throws Exception {
         final InstanceMetadata metadata = new InstanceMetadata(
                 advertiser.getInstanceId(), advertiser.getListenAddress(),
-                advertiser.getListenPort());
+                advertiser.getListenPort(), advertiser.getAdminPort());
         return ServiceInstance.<InstanceMetadata> builder().name(serviceName)
                 .address(advertiser.getListenAddress())
                 .port(advertiser.getListenPort())

--- a/src/main/java/io/dropwizard/discovery/core/InstanceMetadata.java
+++ b/src/main/java/io/dropwizard/discovery/core/InstanceMetadata.java
@@ -2,6 +2,7 @@ package io.dropwizard.discovery.core;
 
 import io.dropwizard.validation.PortRange;
 import java.util.UUID;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.NotEmpty;
@@ -9,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import com.google.common.base.Optional;
 
 @Immutable
 public final class InstanceMetadata {
@@ -22,13 +24,23 @@ public final class InstanceMetadata {
     @PortRange
     private final int listenPort;
 
+    @Nullable
+    @PortRange
+    private final Integer adminPort;
+
     @JsonCreator
     public InstanceMetadata(@JsonProperty("instanceId") final UUID instanceId,
             @JsonProperty("listenAddress") final String listenAddress,
-            @JsonProperty("listenPort") final int listenPort) {
+            @JsonProperty("listenPort") final int listenPort,
+            @JsonProperty("adminPort") final Optional<Integer> adminPort) {
         this.instanceId = instanceId;
         this.listenAddress = listenAddress;
         this.listenPort = listenPort;
+        if (adminPort == null) {
+            this.adminPort = null;
+        } else {
+            this.adminPort = adminPort.orNull();
+        }
     }
 
     @JsonProperty
@@ -46,6 +58,11 @@ public final class InstanceMetadata {
         return listenPort;
     }
 
+    @JsonProperty
+    public Optional<Integer> getAdminPort() {
+        return Optional.fromNullable(adminPort);
+    }
+
     @Override
     public boolean equals(final Object obj) {
         if (this == obj) {
@@ -58,18 +75,21 @@ public final class InstanceMetadata {
         final InstanceMetadata other = (InstanceMetadata) obj;
         return Objects.equal(instanceId, other.instanceId)
                 && Objects.equal(listenAddress, other.listenAddress)
-                && Objects.equal(listenPort, other.listenPort);
+                && Objects.equal(listenPort, other.listenPort)
+                && Objects.equal(adminPort, other.adminPort);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(instanceId, listenAddress, listenPort);
+        return Objects.hashCode(instanceId, listenAddress, listenPort,
+                adminPort);
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this).add("instanceId", instanceId)
                 .add("listenAddress", listenAddress)
-                .add("listenPort", listenPort).toString();
+                .add("listenPort", listenPort).add("adminPort", adminPort)
+                .toString();
     }
 }

--- a/src/main/java/io/dropwizard/discovery/manage/CuratorManager.java
+++ b/src/main/java/io/dropwizard/discovery/manage/CuratorManager.java
@@ -5,7 +5,6 @@ import io.dropwizard.lifecycle.Managed;
 import javax.annotation.Nonnull;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
-import org.apache.curator.utils.EnsurePath;
 
 public class CuratorManager implements Managed {
 
@@ -21,8 +20,8 @@ public class CuratorManager implements Managed {
         this.framework = checkNotNull(framework);
         // start framework directly to allow other bundles to interact with
         // zookeeper during their run() method.
-        if (framework.getState() != CuratorFrameworkState.STARTED) {
-            framework.start();
+        if (this.framework.getState() != CuratorFrameworkState.STARTED) {
+            this.framework.start();
         }
     }
 
@@ -30,7 +29,7 @@ public class CuratorManager implements Managed {
     public void start() throws Exception {
         // framework was already started in constructor
         // ensure that the root path is available
-        new EnsurePath("/").ensure(framework.getZookeeperClient());
+        framework.create().creatingParentsIfNeeded().forPath("/");
     }
 
     @Override

--- a/src/main/java/io/dropwizard/discovery/manage/CuratorManager.java
+++ b/src/main/java/io/dropwizard/discovery/manage/CuratorManager.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import javax.annotation.Nonnull;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
+import org.apache.zookeeper.data.Stat;
 import io.dropwizard.lifecycle.Managed;
 
 public class CuratorManager implements Managed {
@@ -27,9 +28,12 @@ public class CuratorManager implements Managed {
 
     @Override
     public void start() throws Exception {
-        // framework was already started in constructor
-        // ensure that the root path is available
-        framework.create().creatingParentsIfNeeded().forPath("/");
+        framework.blockUntilConnected();
+        final Stat stat = framework.checkExists().forPath("/");
+        if (stat == null) {
+            // ensure that the root path is available
+            framework.create().creatingParentsIfNeeded().forPath("/");
+        }
     }
 
     @Override

--- a/src/test/java/io/dropwizard/discovery/core/CuratorAdvertiserTest.java
+++ b/src/test/java/io/dropwizard/discovery/core/CuratorAdvertiserTest.java
@@ -9,6 +9,7 @@ import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceInstance;
 import org.junit.Before;
 import org.junit.Test;
+import com.google.common.base.Optional;
 
 public class CuratorAdvertiserTest {
 
@@ -26,8 +27,19 @@ public class CuratorAdvertiserTest {
     @Test
     public void testInitListenInfo() throws Exception {
         factory.setListenAddress("127.0.0.1");
-        advertiser.initListenInfo(8080);
+        advertiser.initListenInfo(8080, 8180);
         assertThat(advertiser.getListenPort()).isEqualTo(8080);
+        assertThat(advertiser.getAdminPort()).isEqualTo(Optional.of(8180));
+        assertThat(advertiser.getListenAddress()).isEqualTo("127.0.0.1");
+    }
+
+    @Test
+    public void testInitListenInfoNoAdmin() throws Exception {
+        factory.setListenAddress("127.0.0.1");
+        advertiser.initListenInfo(8080, null);
+        assertThat(advertiser.getListenPort()).isEqualTo(8080);
+        assertThat(advertiser.getAdminPort()).isEqualTo(
+                Optional.<Integer> absent());
         assertThat(advertiser.getListenAddress()).isEqualTo("127.0.0.1");
     }
 
@@ -39,7 +51,7 @@ public class CuratorAdvertiserTest {
         } catch (final IllegalStateException ignore) {
         }
 
-        advertiser.initListenInfo(8080);
+        advertiser.initListenInfo(8080, null);
         advertiser.checkInitialized();
     }
 
@@ -51,7 +63,7 @@ public class CuratorAdvertiserTest {
         } catch (final IllegalStateException ignore) {
         }
 
-        advertiser.initListenInfo(8080);
+        advertiser.initListenInfo(8080, null);
         final ServiceInstance<InstanceMetadata> instance = advertiser
                 .getInstance();
         advertiser.registerAvailability(instance);
@@ -66,7 +78,7 @@ public class CuratorAdvertiserTest {
         } catch (final IllegalStateException ignore) {
         }
 
-        advertiser.initListenInfo(8080);
+        advertiser.initListenInfo(8080, null);
         final ServiceInstance<InstanceMetadata> instance = advertiser
                 .getInstance();
         advertiser.unregisterAvailability(instance);

--- a/src/test/java/io/dropwizard/discovery/manage/CuratorManagerTest.java
+++ b/src/test/java/io/dropwizard/discovery/manage/CuratorManagerTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.when;
 import org.apache.curator.CuratorZookeeperClient;
 import org.apache.curator.RetryLoop;
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.CreateBuilder;
+import org.apache.curator.framework.api.ProtectACLCreateModePathAndBytesable;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -13,6 +15,9 @@ public class CuratorManagerTest {
 
     private final CuratorFramework framework = mock(CuratorFramework.class);
     private final CuratorZookeeperClient client = mock(CuratorZookeeperClient.class);
+    private final CreateBuilder create = mock(CreateBuilder.class);
+    @SuppressWarnings("unchecked")
+    private final ProtectACLCreateModePathAndBytesable<String> acl = mock(ProtectACLCreateModePathAndBytesable.class);
     private final RetryLoop loop = mock(RetryLoop.class);
     private final CuratorManager manager = new CuratorManager(framework);
 
@@ -20,6 +25,8 @@ public class CuratorManagerTest {
     public void setUp() {
         when(framework.getZookeeperClient()).thenReturn(client);
         when(client.newRetryLoop()).thenReturn(loop);
+        when(framework.create()).thenReturn(create);
+        when(create.creatingParentsIfNeeded()).thenReturn(acl);
         when(loop.shouldContinue()).thenReturn(true).thenReturn(false);
     }
 

--- a/src/test/java/io/dropwizard/discovery/manage/CuratorManagerTest.java
+++ b/src/test/java/io/dropwizard/discovery/manage/CuratorManagerTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.when;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.CreateBuilder;
 import org.apache.curator.framework.api.ExistsBuilder;
-import org.apache.curator.framework.api.ProtectACLCreateModeStatPathAndBytesable;
+import org.apache.curator.framework.api.ProtectACLCreateModePathAndBytesable;
 import org.apache.zookeeper.data.Stat;
 import org.junit.After;
 import org.junit.Before;
@@ -20,8 +20,8 @@ public class CuratorManagerTest {
     private final CreateBuilder create = mock(CreateBuilder.class);
     private final ExistsBuilder exists = mock(ExistsBuilder.class);
     @SuppressWarnings("unchecked")
-    private final ProtectACLCreateModeStatPathAndBytesable<String> acl = mock(
-            ProtectACLCreateModeStatPathAndBytesable.class);
+    private final ProtectACLCreateModePathAndBytesable<String> acl = mock(
+            ProtectACLCreateModePathAndBytesable.class);
     private final CuratorManager manager = new CuratorManager(framework);
 
     @Before

--- a/src/test/java/io/dropwizard/discovery/manage/CuratorManagerTest.java
+++ b/src/test/java/io/dropwizard/discovery/manage/CuratorManagerTest.java
@@ -1,18 +1,24 @@
 package io.dropwizard.discovery.manage;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.CreateBuilder;
+import org.apache.curator.framework.api.ExistsBuilder;
 import org.apache.curator.framework.api.ProtectACLCreateModeStatPathAndBytesable;
+import org.apache.zookeeper.data.Stat;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 public class CuratorManagerTest {
 
     private final CuratorFramework framework = mock(CuratorFramework.class);
-    private final CreateBuilder builder = mock(CreateBuilder.class);
+    private final CreateBuilder create = mock(CreateBuilder.class);
+    private final ExistsBuilder exists = mock(ExistsBuilder.class);
     @SuppressWarnings("unchecked")
     private final ProtectACLCreateModeStatPathAndBytesable<String> acl = mock(
             ProtectACLCreateModeStatPathAndBytesable.class);
@@ -20,13 +26,26 @@ public class CuratorManagerTest {
 
     @Before
     public void setUp() {
+        when(framework.create()).thenReturn(create);
+        when(framework.checkExists()).thenReturn(exists);
+        when(create.creatingParentsIfNeeded()).thenReturn(acl);
+    }
 
-        when(framework.create()).thenReturn(builder);
-        when(builder.creatingParentsIfNeeded()).thenReturn(acl);
+    @After
+    public void tearDown() {
+        reset(framework);
     }
 
     @Test
-    public void testStart() throws Exception {
+    public void testStartRootExists() throws Exception {
+        when(exists.forPath("/")).thenReturn(new Stat());
+        manager.start();
+        verify(framework, never()).create();
+    }
+
+    @Test
+    public void testStartRootMissing() throws Exception {
+        when(exists.forPath("/")).thenReturn(null);
         manager.start();
         verify(framework).create();
     }


### PR DESCRIPTION
I made the `adminPort` Optional because the Dropwizard simple server doesn't expose and admin port, only the listen port.  The Dropwizard default server exposes both.

Fixes #10 