### PR TITLE
Update TravisCI Build (#45)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ dist: trusty
 language: java
 jdk:
   - openjdk8
+  - openjdk11
 before_install:
-  - rm ~/.m2/settings.xml || true 
+  - rm ~/.m2/settings.xml || true
   - ulimit -c unlimited -S
   - mvn -N io.takari:maven:wrapper
 after_success:

--- a/.travis_after_success.sh
+++ b/.travis_after_success.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ "${TRAVIS_JDK_VERSION}" != "oraclejdk8" ]]; then
+if [[ "${TRAVIS_JDK_VERSION}" != "openjdk8" ]]; then
     echo "Skipping after_success actions for JDK version \"${TRAVIS_JDK_VERSION}\""
     exit
 fi
@@ -17,7 +17,7 @@ if [[ ${TRAVIS_BRANCH} != 'master' ]]; then
     exit
 fi
 
-if [[ "$TRAVIS_PULL_REQUEST" = "true" ]]; then
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
     echo "Skipping deployment for pull request"
     exit
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,12 @@
             <email>jplock@smoketurner.com</email>
             <timezone>America/New_York</timezone>
         </developer>
+        <developer>
+            <id>kstafford3</id>
+            <name>Kyle Stafford</name>
+            <email>kyle@kstafford3.com</email>
+            <timezone>America/New_York</timezone>
+        </developer>
     </developers>
 
     <properties>


### PR DESCRIPTION
Build against openjdk8 and 11

Summary:
=======
Our travis ci config currently only tests against openjdk8.
The snapshot-release script is currently written to never run.

Actions:
=======
* Add 'openjdk11' to the travis config.
* Modify the snapshot-release script to run in the openjdk8 environment
* Unrelated: add myself to the developer list in the pom.