### PR TITLE
Simplify release signing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,8 +121,7 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <passphrase>${gpg.passphrase}</passphrase>
-                            <keyname>8812F4E9</keyname>
+                            <keyname>${gpg.keyname}</keyname>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -486,7 +485,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
-                    <arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <mavenExecutorId>forked-path</mavenExecutorId>
                     <tagNameFormat>v@{project.version}</tagNameFormat>


### PR DESCRIPTION
Keyname from maven settings, prompt for password

Summary:
=======
GPG Key name should be dictated by the local settings of the deployer, not by the maven pom.
We can let gpg prompt for the key's password.
This will simplify release/deploy arguments.

Actions:
=======
* Remove the hard-coded gpg keyname from the pom.
* Remove references to ${gpg.passphrase} from the pom.