### PR TITLE
Initial integration test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
         </dependency>

--- a/src/test/java/io/dropwizard/discovery/DiscoveryBundleIntegrationTest.java
+++ b/src/test/java/io/dropwizard/discovery/DiscoveryBundleIntegrationTest.java
@@ -1,0 +1,63 @@
+package io.dropwizard.discovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.TestingServer;
+import org.apache.curator.x.discovery.ServiceInstance;
+import org.apache.curator.x.discovery.details.InstanceSerializer;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import io.dropwizard.discovery.core.InstanceMetadata;
+import io.dropwizard.discovery.core.JacksonInstanceSerializer;
+import io.dropwizard.discovery.testutil.TestApplication;
+import io.dropwizard.discovery.testutil.TestConfiguration;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+
+public class DiscoveryBundleIntegrationTest {
+    private static final String NAMESPACE = "dropwizard";
+    private static final String SERVICE_NAME = "test-service";
+    private static final String SERVICE_PATH = "/service/" + SERVICE_NAME;
+
+    @ClassRule
+    public static final DropwizardAppRule<TestConfiguration> RULE = new DropwizardAppRule<TestConfiguration>(
+            TestApplication.class, ResourceHelpers.resourceFilePath("test-config.yaml"));
+
+    InstanceSerializer<InstanceMetadata> serializer = new JacksonInstanceSerializer<InstanceMetadata>(
+            RULE.getObjectMapper(), new TypeReference<ServiceInstance<InstanceMetadata>>() {
+            });
+
+    private String instancePath(String instanceNode) {
+        return new StringBuilder(SERVICE_PATH).append("/").append(instanceNode).toString();
+    }
+
+    @Test
+    public void testRegistration() throws Exception {
+        // use a separate instance of curator to pull out the app's data
+        TestingServer testingServer = RULE.getConfiguration().getTestingServer();
+        try (final CuratorFramework curatorFramework = CuratorFrameworkFactory
+                .newClient(testingServer.getConnectString(), new RetryOneTime(1))) {
+            curatorFramework.start();
+
+            List<String> instanceNames = curatorFramework.usingNamespace(NAMESPACE).getChildren().forPath(SERVICE_PATH);
+            assertThat(instanceNames).hasSize(1);
+
+            String instanceName = instanceNames.get(0);
+            byte[] instanceData = curatorFramework.usingNamespace(NAMESPACE).getData()
+                    .forPath(instancePath(instanceName));
+
+            ServiceInstance<InstanceMetadata> serviceInstanceMetadata = serializer.deserialize(instanceData);
+
+            assertThat(serviceInstanceMetadata).isNotNull();
+            assertThat(serviceInstanceMetadata.getName()).isEqualTo(SERVICE_NAME);
+        }
+    }
+}

--- a/src/test/java/io/dropwizard/discovery/testutil/TestApplication.java
+++ b/src/test/java/io/dropwizard/discovery/testutil/TestApplication.java
@@ -1,0 +1,47 @@
+package io.dropwizard.discovery.testutil;
+
+import org.apache.curator.test.TestingServer;
+
+import io.dropwizard.Application;
+import io.dropwizard.discovery.DiscoveryBundle;
+import io.dropwizard.discovery.DiscoveryFactory;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+
+public class TestApplication extends Application<TestConfiguration> {
+    private TestingServer testingServer;
+
+    public TestApplication() {
+        try {
+            this.testingServer = new TestingServer();
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not initialize testing server", e);
+        }
+    }
+
+    private final DiscoveryBundle<TestConfiguration> discoveryBundle = new DiscoveryBundle<TestConfiguration>() {
+        @Override
+        public DiscoveryFactory getDiscoveryFactory(TestConfiguration configuration) {
+            return new TestDiscoveryFactory(testingServer, configuration.getServiceName());
+        }
+
+        @Override
+        public void run(TestConfiguration configuration, Environment environment) throws Exception {
+            // Managed resources stop in reverse-order of how they started
+            // We want to stop the testing server after the DiscoveryBundle stops.
+            environment.lifecycle().manage(new TestingServerManager(testingServer));
+            super.run(configuration, environment);
+        }
+    };
+
+    @Override
+    public void initialize(Bootstrap<TestConfiguration> bootstrap) {
+        bootstrap.addBundle(discoveryBundle);
+    }
+
+    @Override
+    public void run(TestConfiguration configuration, Environment environment) throws Exception {
+        // use the configuration to pass this application's testing server to the test
+        configuration.setTestingServer(testingServer);
+    }
+}

--- a/src/test/java/io/dropwizard/discovery/testutil/TestConfiguration.java
+++ b/src/test/java/io/dropwizard/discovery/testutil/TestConfiguration.java
@@ -1,0 +1,39 @@
+package io.dropwizard.discovery.testutil;
+
+import org.apache.curator.test.TestingServer;
+import org.hibernate.validator.constraints.NotBlank;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.dropwizard.Configuration;
+
+public class TestConfiguration extends Configuration {
+    @NotBlank
+    private String serviceName = "test-service";
+
+    /**
+     * This is set by TestingApplication during DiscoveryBundle initialization.
+     * <p>
+     * It is retrieved in tests through DropwizardAppRule or
+     * DropwizardTestingSupport.
+     **/
+    private TestingServer testingServer = null;
+
+    @JsonProperty
+    public String getServiceName() {
+        return this.serviceName;
+    }
+
+    @JsonProperty
+    public void setServiceName(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    public TestingServer getTestingServer() {
+        return testingServer;
+    }
+
+    public void setTestingServer(TestingServer testingServer) {
+        this.testingServer = testingServer;
+    }
+}

--- a/src/test/java/io/dropwizard/discovery/testutil/TestDiscoveryFactory.java
+++ b/src/test/java/io/dropwizard/discovery/testutil/TestDiscoveryFactory.java
@@ -1,0 +1,20 @@
+package io.dropwizard.discovery.testutil;
+
+import org.apache.curator.test.TestingServer;
+
+import io.dropwizard.discovery.DiscoveryFactory;
+
+public class TestDiscoveryFactory extends DiscoveryFactory {
+    private final TestingServer testingServer;
+
+    public TestDiscoveryFactory(TestingServer testingServer, String serviceName) {
+        this.setServiceName(serviceName);
+        this.testingServer = testingServer;
+    }
+
+    @Override
+    public String getQuorumSpec() {
+        return testingServer.getConnectString();
+    }
+
+}

--- a/src/test/java/io/dropwizard/discovery/testutil/TestingServerManager.java
+++ b/src/test/java/io/dropwizard/discovery/testutil/TestingServerManager.java
@@ -1,0 +1,25 @@
+package io.dropwizard.discovery.testutil;
+
+import org.apache.curator.test.TestingServer;
+
+import io.dropwizard.lifecycle.Managed;
+
+public class TestingServerManager implements Managed {
+
+    private final TestingServer testingServer;
+
+    public TestingServerManager(TestingServer testingServer) {
+        this.testingServer = testingServer;
+    }
+
+    @Override
+    public void start() throws Exception {
+        this.testingServer.start();
+    }
+
+    @Override
+    public void stop() throws Exception {
+        this.testingServer.stop();
+    }
+
+}

--- a/src/test/resources/test-config.yaml
+++ b/src/test/resources/test-config.yaml
@@ -1,0 +1,2 @@
+server:
+  type: default


### PR DESCRIPTION
Register a dropwizard app with the discovery bundle.

Summary:
=======
In order to test features that are more tightly coupled with curator, we will need to use integration tests.

Our first test is to assert that a dropwizard application with the discovery bundle added will register the service.

We will use DropwizardAppRule to set up a trivial dropwizard application with the discovery bundle added.
We will use curator's provided TestingServer to take the place of an actual zookeeper instance.
We will use curator to access the TestingServer to verify that instance metadata has been posted.

We need to share the TestingServer between the bundle and the test.
To do this, we will use a custom Configuration class.
TestApplication will initialize the TestingServer and pass it to the configuration.
The configuration is shared with the test, and the TestingServer can be retrieved there.

Adding this integration test has revealed some exceptions that get thrown when running an application with this bundle in java 11.
Java 11 has removed some modules, we need to explicitly add them to the classpath.
Without these modules, NoClassDefFoundError exceptions will fire.
These exceptions appear to be caught, but we can avoid them altogether by adding the dependencies explicitly.

Actions:
=======
* Create TestDiscoveryFactory, a subclass of DiscoveryFactory that returns a quorumSpec (connection string) based on a TestingServer's connection string.
* Create TestingServerManager, an implementation of Managed that stops the TestingServer at the end of the app lifecycle.
* Create TestConfiguration to configure the application that integrations tests will run against.
  * TestConfiguration will also hold the TestingServer once the application is running.
* Create TestApplication, a trivial dropwizard application with the discovery bundle initialized/bootstrapped.
  * TestApplication initializes the TestingServer and passes it to the TestConfiguration.
  * TestApplication also registers a TestingServerManager for TestingServer, to ensure it is properly shut down after the test.
* Create test-config.yaml, a baseline configuration to initialize TestConfiguration.
* Create DiscoveryBundleIntegrationTest.
* Add a DropwizardAppRule to DiscoveryBundleIntegrationTest to initialize a TestApplication with test-config.yaml.
* Add a test that uses curator to assert that the bundle has registered an instance of a service.
  * Initialize a CuratorFramework with the TestingServer from TestConfiguration.
  * Search for the node under the expected namespace, base-path, and service name.
  * Use the node name to retrieve the serialized ServiceInstance.
  * Deserialize the instance and assert that the retrieved object is in-tact.
* Include javax.xml.bind.jaxb-api 2.3.1 as a dependency.
* Include javax.activation.activation 1.1.1 as a dependency.