### PR TITLE
Update mvn project-info-reports-plugin goals

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -515,12 +515,12 @@
                             <report>index</report>
                             <report>summary</report>
                             <report>dependency-info</report>
-                            <report>license</report>
+                            <report>licenses</report>
                             <report>scm</report>
-                            <report>issue-tracking</report>
-                            <report>mailing-list</report>
-                            <report>cim</report>
-                            <report>project-team</report>
+                            <report>issue-management</report>
+                            <report>mailing-lists</report>
+                            <report>ci-management</report>
+                            <report>team</report>
                             <report>dependencies</report>
                             <report>dependency-convergence</report>
                             <report>modules</report>


### PR DESCRIPTION
Goal name changes

Summary:
=======
Version three of the project-info-reports-plugin changed some of the goal names.
In order to generate the project site, we need to fix those names.

Actions:
=======
* Fix goal names